### PR TITLE
Escape apostrophe in footer address

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -67,7 +67,7 @@ export function Footer() {
               <p>
                 1-3, 1 ALLEE LAVOISIER
                 <br />
-                59650 VILLENEUVE-D'ASCQ
+                59650 VILLENEUVE-D&apos;ASCQ
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- escape apostrophe in footer address to satisfy React lint rule

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac3d18439c8324802a9d6da3774503