### PR TITLE
feat: add email contact API

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,27 +1,26 @@
 import { NextResponse } from "next/server"
-import nodemailer from "nodemailer"
 
 export async function POST(req: Request) {
   try {
     const { nom, email, telephone, message } = await req.json()
 
-    const transporter = nodemailer.createTransport({
-      host: "smtp.gmail.com",
-      port: 587,
-      secure: false,
-      auth: {
-        user: process.env.EMAIL_USER,
-        pass: process.env.EMAIL_PASS,
+    const response = await fetch(
+      "https://formsubmit.co/ajax/osm.gouna@gmail.com",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ nom, email, telephone, message }),
       },
-    })
+    )
 
-    await transporter.sendMail({
-      from: process.env.EMAIL_USER,
-      to: "osm.gouna@gmail.com",
-      replyTo: email,
-      subject: `Nouveau message de ${nom}`,
-      text: `Nom: ${nom}\nEmail: ${email}\nTéléphone: ${telephone}\n\n${message}`,
-    })
+    if (!response.ok) {
+      const text = await response.text()
+      console.error("Email service error", text)
+      return NextResponse.json({ success: false }, { status: 502 })
+    }
 
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import nodemailer from "nodemailer"
+
+export async function POST(req: Request) {
+  try {
+    const { nom, email, telephone, message } = await req.json()
+
+    const transporter = nodemailer.createTransport({
+      host: "smtp.gmail.com",
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+    })
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_USER,
+      to: "osm.gouna@gmail.com",
+      replyTo: email,
+      subject: `Nouveau message de ${nom}`,
+      text: `Nom: ${nom}\nEmail: ${email}\nTéléphone: ${telephone}\n\n${message}`,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/components/sections/contact.tsx
+++ b/components/sections/contact.tsx
@@ -108,13 +108,27 @@ export function Contact() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsSubmitting(true)
-    await new Promise((resolve) => setTimeout(resolve, 2000))
-    setIsSubmitting(false)
-    setSubmitStatus("success")
-    setTimeout(() => {
-      setFormData({ nom: "", email: "", telephone: "", message: "" })
-      setSubmitStatus("idle")
-    }, 3000)
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      })
+      if (res.ok) {
+        setSubmitStatus("success")
+        setFormData({ nom: "", email: "", telephone: "", message: "" })
+      } else {
+        setSubmitStatus("error")
+      }
+    } catch (error) {
+      console.error(error)
+      setSubmitStatus("error")
+    } finally {
+      setIsSubmitting(false)
+      setTimeout(() => setSubmitStatus("idle"), 3000)
+    }
   }
 
   return (

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.540.0",
     "next": "15.2.4",
-    "nodemailer": "^6.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-leaflet": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.540.0",
     "next": "15.2.4",
+    "nodemailer": "^6.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-leaflet": "^5.0.0",


### PR DESCRIPTION
## Summary
- create /api/contact route using nodemailer to forward messages
- hook contact form to call backend
- add nodemailer dependency for email sending

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve 'nodemailer')*

------
https://chatgpt.com/codex/tasks/task_e_68b75ba9482483249ac4bb31dc2317c1