### PR TITLE
feat: add email contact API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+BREVO_API_KEY=your_brevo_api_key
+BREVO_SENDER_EMAIL=your_verified_sender@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Contact form setup
+
+The `/api/contact` route sends messages through [Brevo](https://www.brevo.com/)'s transactional email API. To receive emails from the contact form, create a `.env` file based on `.env.example` and provide your Brevo API key and a verified sender address:
+
+```bash
+BREVO_API_KEY=your_brevo_api_key
+BREVO_SENDER_EMAIL=your_verified_sender@example.com
+```
+
+Brevo offers a free tier (300 emails/day) and will forward all submissions to `osm.gouna@gmail.com`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+
+export async function POST(req: Request) {
+  try {
+    const { nom, email, telephone, message } = await req.json()
+
+    const response = await fetch("https://api.brevo.com/v3/smtp/email", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": process.env.BREVO_API_KEY ?? "",
+      },
+      body: JSON.stringify({
+        to: [{ email: "osm.gouna@gmail.com" }],
+        sender: {
+          email: process.env.BREVO_SENDER_EMAIL ?? "no-reply@data4you.fr",
+        },
+        subject: `Nouveau message de ${nom}`,
+        htmlContent: `
+          <p><strong>Nom:</strong> ${nom}</p>
+          <p><strong>Email:</strong> ${email}</p>
+          <p><strong>Téléphone:</strong> ${telephone}</p>
+          <p><strong>Message:</strong><br/>${message}</p>
+        `,
+      }),
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      console.error("Email service error", text)
+      return NextResponse.json({ success: false }, { status: 502 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/components/sections/contact.tsx
+++ b/components/sections/contact.tsx
@@ -108,13 +108,27 @@ export function Contact() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsSubmitting(true)
-    await new Promise((resolve) => setTimeout(resolve, 2000))
-    setIsSubmitting(false)
-    setSubmitStatus("success")
-    setTimeout(() => {
-      setFormData({ nom: "", email: "", telephone: "", message: "" })
-      setSubmitStatus("idle")
-    }, 3000)
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      })
+      if (res.ok) {
+        setSubmitStatus("success")
+        setFormData({ nom: "", email: "", telephone: "", message: "" })
+      } else {
+        setSubmitStatus("error")
+      }
+    } catch (error) {
+      console.error(error)
+      setSubmitStatus("error")
+    } finally {
+      setIsSubmitting(false)
+      setTimeout(() => setSubmitStatus("idle"), 3000)
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- replace Formsubmit with Brevo to send contact form emails to osm.gouna@gmail.com
- document Brevo credentials in README and `.env.example`
- allow committing `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75ba9482483249ac4bb31dc2317c1